### PR TITLE
Drill down to specific check for SearchWorks Solr

### DIFF
--- a/src/endpointParsers.js
+++ b/src/endpointParsers.js
@@ -7,7 +7,7 @@ export function processSearchworks(response) {
 export function processSwSolr(response) {
   return response.json().then(function(data) {
     if (typeof data.default === 'undefined') return 'outage';
-    return data.default.success ? 'up' : 'outage';
+    return data.sw_solr.success ? 'up' : 'outage';
   });
 }
 export function processEbsco(response) {


### PR DESCRIPTION
We were just checking the default Searchworks application test before. This narrows the check down to https://searchworks.stanford.edu/status/sw_solr.json