### PR TITLE
Add a z-index of 5 to the header so that animated text/icons are not…

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -22,6 +22,7 @@ p {
     border-width: 0 0 1px 0;
     border-color: lightgray;
     border-style: solid;
+    z-index: 5;
 }
 
 .nav-menu {


### PR DESCRIPTION
…overlaid on the header.

## Before 

![before-z-index](https://user-images.githubusercontent.com/96776/45125206-4e921100-b122-11e8-8268-96b0831da912.gif)

## After

![after-z-index](https://user-images.githubusercontent.com/96776/45125205-4e921100-b122-11e8-9c9b-5a11c60100ff.gif)
