### PR TITLE
Add the notion of a fatal vs non-fatal global outage (+ tests for the…

### DIFF
--- a/__tests__/components/GlobalStatusSummary.test.js
+++ b/__tests__/components/GlobalStatusSummary.test.js
@@ -1,0 +1,24 @@
+// Test Utilities
+import React from 'react';
+import { shallow } from 'enzyme';
+import { statuses } from '../../src/config';
+// Component to be tested
+import GlobalStatusSummary from '../../src/components/GlobalStatusSummary';
+
+
+describe('<GlobalStatusSummary />', () => {
+
+  it('renders the given status', () => {
+    const wrapper = shallow(<GlobalStatusSummary status={statuses.outage} />);
+
+    expect(wrapper.find('h1').text()).toEqual('🚫')
+    expect(wrapper.find('h3').text()).toEqual('Outage')
+    expect(wrapper.find('p').text()).toEqual('This service is currently unavailable due to an outage.')
+  });
+
+  it('renders a global status message if present', () => {
+    const wrapper = shallow(<GlobalStatusSummary status={statuses.issue} />);
+
+    expect(wrapper.find('p').text()).toMatch(/There is currently an issue with SearchWorks or a related service/)
+  });
+});

--- a/__tests__/utils/globalStatus.test.js
+++ b/__tests__/utils/globalStatus.test.js
@@ -1,0 +1,126 @@
+// Test Utilities
+import { statusEndpoints, statuses } from '../../src/config';
+import GlobalStatus from '../../src/utils/globalStatus';
+
+const originalStatusEndpoints = statusEndpoints;
+
+describe('<GlobalStatus />', () => {
+  afterEach(() => {
+    Object.keys(statusEndpoints).forEach((key) => {
+      statusEndpoints[key].status = 'pending'
+    });
+  });
+
+  it('renders a pending status', () => {
+    const status = new GlobalStatus(statuses, statusEndpoints).status;
+
+    expect(status.icon).toEqual('🔄');
+  });
+
+  describe('Up', () => {
+    beforeEach(() => {
+      Object.keys(statusEndpoints).forEach((key) => {
+        statusEndpoints[key].status = 'up';
+      });
+    });
+
+    it('renders the GlobalStatusSummary component as up', () => {
+      const status = new GlobalStatus(statuses, statusEndpoints).status;
+
+      expect(status.icon).toEqual('✅');
+    });
+  });
+
+  describe('Maintenance', () => {
+    beforeEach(() => {
+      Object.keys(statusEndpoints).forEach((key) => {
+        statusEndpoints[key].status = 'maintenance';
+      });
+    });
+
+    it('renders the GlobalStatusSummary component as in maintenance mode if any of the statuses are "maintenance"', () => {
+      const status = new GlobalStatus(statuses, statusEndpoints).status;
+
+      expect(status.icon).toEqual('🛠');
+    });
+  });
+
+  describe('Fatal', () => {
+    describe('when just the SearchWorks web app is down', () => {
+      beforeEach(() => {
+        statusEndpoints.searchworksApplication.status = 'outage';
+      });
+
+      it('renders the component as fatal', () => {
+        const status = new GlobalStatus(statuses, statusEndpoints).status;
+
+        expect(status.icon).toEqual('🚫');
+        expect(status.global_message).toEqual('SearchWorks is experiencing a complete outage.');
+      });
+    });
+
+    describe('when the SearchWorks web app is up but solr and the Aricle API is down', () => {
+      beforeEach(() => {
+        statusEndpoints.searchworksApplication.status = 'up';
+        statusEndpoints.swSolr.status = 'outage';
+        statusEndpoints.ebsco.status = 'outage';
+      });
+
+      it('renders the component as fatal', () => {
+        const status = new GlobalStatus(statuses, statusEndpoints).status;
+
+        expect(status.icon).toEqual('🚫');
+        expect(status.global_message).toEqual('SearchWorks is experiencing a complete outage.');
+      });
+    });
+  });
+
+  describe('Outage', () => {
+    describe('when a critical service has an outage', () => {
+      beforeEach(() => {
+        statusEndpoints.searchworksApplication.status = 'up';
+        statusEndpoints.swSolr.status = 'up';
+        statusEndpoints.ebsco.status = 'outage';
+      });
+
+      it('renders the component as an outage', () => {
+        const status = new GlobalStatus(statuses, statusEndpoints).status;
+
+        expect(status.icon).toEqual('🚫');
+        expect(status.message).toEqual('This service is currently unavailable due to an outage.');
+      });
+    });
+  });
+
+  describe('Issue', () => {
+    describe('when a non-critical service has an outage', () => {
+      beforeEach(() => {
+        statusEndpoints.requests.status = 'outage';
+      });
+
+      it('renders the component as an issue', () => {
+        const status = new GlobalStatus(statuses, statusEndpoints).status;
+
+        expect(status.icon).toEqual('⚠️');
+        expect(status.global_message).toEqual(
+          'There is currently an issue with SearchWorks or a related service. Please see below for more details.'
+        );
+      });
+    });
+
+    describe('when any service has an issue', () => {
+      beforeEach(() => {
+        statusEndpoints.swSolr.status = 'issue';
+      });
+
+      it('renders the component as an issue', () => {
+        const status = new GlobalStatus(statuses, statusEndpoints).status;
+
+        expect(status.icon).toEqual('⚠️');
+        expect(status.global_message).toEqual(
+          'There is currently an issue with SearchWorks or a related service. Please see below for more details.'
+        );
+      });
+    });
+  });
+});

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -14,6 +14,7 @@ import {
   processLiveAvailability,
   processCitationService,
 } from '../utils/endpointParsers';
+import GlobalStatus from '../utils/globalStatus';
 import GlobalStatusSummary from './GlobalStatusSummary';
 import StatusHeader from './StatusHeader';
 import StatusItem from './StatusItem';
@@ -133,8 +134,7 @@ class Dashboard extends React.Component {
     return (
       <div>
         <GlobalStatusSummary
-          endpoints={endpoints}
-          statuses={statuses}
+          status={new GlobalStatus(statuses, endpoints).status}
         />
         <div id="services">
           <StatusHeader

--- a/src/components/GlobalStatusSummary.jsx
+++ b/src/components/GlobalStatusSummary.jsx
@@ -1,46 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const statusReducer = (endpointStatuses) => {
-  const allAreUp = Object.keys(endpointStatuses).every(e => endpointStatuses[e].status === 'up');
-  const anyIssues = Object.keys(endpointStatuses).some(e => endpointStatuses[e].status === 'issue');
-  const anyMaintenance = Object.keys(endpointStatuses).some(e => endpointStatuses[e].status === 'maintenance');
-  const criticalEndpoints = Object.keys(endpointStatuses).filter(e => endpointStatuses[e].critical);
-  const nonCriticalEndpoints = Object.keys(endpointStatuses)
-    .filter(e => !endpointStatuses[e].critical);
-  const anyNonCriticalOutages = nonCriticalEndpoints.some(e => endpointStatuses[e].status === 'outage');
-  const anyCriticalOutages = criticalEndpoints.some(e => endpointStatuses[e].status === 'outage');
+const GlobalStatusSummary = ({ status }) => (
 
-  if (allAreUp) {
-    return 'up';
-  } if (anyCriticalOutages) {
-    return 'outage';
-  } if (anyMaintenance) {
-    return 'maintenance';
-  } if (anyIssues || anyNonCriticalOutages) {
-    return 'issue';
-  }
-  return 'pending';
-};
-
-const GlobalStatusSummary = ({
-  statuses, endpoints,
-}) => (
   <div id="GlobalStatusSummary" className="section">
-    <h1>{statuses[statusReducer(endpoints)].icon}</h1>
-    <h3>{statuses[statusReducer(endpoints)].legend}</h3>
+    <h1>{status.icon}</h1>
+    <h3>{status.legend}</h3>
     <p>
-      {
-        statuses[statusReducer(endpoints)].global_message
-        || statuses[statusReducer(endpoints)].message
-      }
+      {status.global_message || status.message}
     </p>
   </div>
 );
 
 GlobalStatusSummary.propTypes = {
-  statuses: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  endpoints: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  status: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
 export default GlobalStatusSummary;

--- a/src/components/StatusHeader.jsx
+++ b/src/components/StatusHeader.jsx
@@ -8,7 +8,7 @@ const StatusHeader = ({ statuses }) => (
       {Object.keys(statuses)
         .map((status) => {
           const currentStatus = statuses[status];
-          if (status !== 'pending') {
+          if (status !== 'pending' && status !== 'fatal') {
             return (
               <div key={status} className="status-legend-item">
                 <p>

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ export const statusEndpoints = {
     displayName: 'SearchWorks Website',
     endpointUrl: 'https://searchworks.stanford.edu/status/all.json',
     status: 'pending',
-    critical: true,
+    critical: true, // While this is technically critical, it will actually trigger a fatal status
     position: 1,
   },
   swSolr: {
@@ -84,6 +84,11 @@ export const statuses = {
     icon: '🚫',
     legend: 'Outage',
     message: 'This service is currently unavailable due to an outage.',
+  },
+  fatal: {
+    icon: '🚫',
+    legend: 'Outage',
+    global_message: 'SearchWorks is experiencing a complete outage.',
   },
 };
 

--- a/src/utils/globalStatus.js
+++ b/src/utils/globalStatus.js
@@ -1,0 +1,67 @@
+class GlobalStatus {
+  constructor(statuses, endpointStatuses) {
+    this.statuses = statuses;
+    this.endpointStatuses = endpointStatuses;
+  }
+
+  get status() {
+    if (this.allAreUp()) {
+      return this.statuses.up;
+    } if (this.anyMaintenance()) {
+      return this.statuses.maintenance;
+    } if (this.anyFatalOutages()) {
+      return this.statuses.fatal;
+    } if (this.anyCriticalOutages()) {
+      return this.statuses.outage;
+    } if (this.anyIssues() || this.anyNonCriticalOutages()) {
+      return this.statuses.issue;
+    }
+    return this.statuses.pending;
+  }
+
+  allAreUp() {
+    return Object.keys(this.endpointStatuses)
+      .every(e => this.endpointStatuses[e].status === 'up');
+  }
+
+  anyIssues() {
+    return Object.keys(this.endpointStatuses)
+      .some(e => this.endpointStatuses[e].status === 'issue');
+  }
+
+  anyMaintenance() {
+    return Object.keys(this.endpointStatuses)
+      .some(e => this.endpointStatuses[e].status === 'maintenance');
+  }
+
+  criticalEndpoints() {
+    return Object.keys(this.endpointStatuses)
+      .filter(e => this.endpointStatuses[e].critical);
+  }
+
+  nonCriticalEndpoints() {
+    return Object.keys(this.endpointStatuses)
+      .filter(e => !this.endpointStatuses[e].critical);
+  }
+
+  anyFatalOutages() {
+    const appStatus = this.endpointStatuses.searchworksApplication.status;
+    const solrStatus = this.endpointStatuses.swSolr.status;
+    const articleStatus = this.endpointStatuses.ebsco.status;
+
+    if (appStatus === 'outage' || (solrStatus === 'outage' && articleStatus === 'outage')) {
+      return true;
+    }
+    return false;
+  }
+
+  anyNonCriticalOutages() {
+    return this.nonCriticalEndpoints().some(e => this.endpointStatuses[e].status === 'outage');
+  }
+
+  anyCriticalOutages() {
+    return this.criticalEndpoints().some(e => this.endpointStatuses[e].status === 'outage');
+  }
+}
+
+export default GlobalStatus;


### PR DESCRIPTION
… GlobalStatusSummary component)

Closes #64 

## Fatal Outages
### Website (same as SOLR & EDS)
<img width="897" alt="website-fatal" src="https://user-images.githubusercontent.com/96776/45507818-f2457780-b747-11e8-886d-bc7358783864.png">

---

### SOLR & EDS (same as website)
<img width="885" alt="non-website-fatal" src="https://user-images.githubusercontent.com/96776/45507884-29b42400-b748-11e8-9f77-bf42727a8127.png">

## Non-Fatal Outage
<img width="875" alt="outage" src="https://user-images.githubusercontent.com/96776/45507970-5cf6b300-b748-11e8-9ea5-09d8bdd19f90.png">

## Issues
### Critical Service (same as non-critical)
<img width="882" alt="critical-issue" src="https://user-images.githubusercontent.com/96776/45508129-e60dea00-b748-11e8-88ec-1284f6643bf2.png">

---

### Non-Critical Service (same as critical)
<img width="889" alt="non-critical-issue" src="https://user-images.githubusercontent.com/96776/45508130-e6a68080-b748-11e8-980d-2d1bd9d8b064.png">
