### PR TITLE
Slightly less janky header links

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -155,7 +155,7 @@ class Dashboard extends React.Component {
           })}
 
         </div>
-        <div className="section">
+        <div id="updates" className="section anchored">
           <TwitterTimelineEmbed
             sourceType="profile"
             screenName="searchworks"

--- a/src/components/GraphPanel.jsx
+++ b/src/components/GraphPanel.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import Graph from './Graph';
 
 const GraphPanel = ({ graphs }) => (
-  <div className="section">
-    <h1 id="graphs">Graphs</h1>
+  <div id="graphs" className="section anchored">
+    <h1>Graphs</h1>
     {
       Object.keys(graphs).map(graphKey => (<Graph graph={graphs[graphKey]} key={graphKey} />))
     }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,8 +7,8 @@ const Header = () => (
     </div>
     <div className="nav-menu">
       <a href="/">Dashboard</a>
-      <a href="#graphs">Graphs</a>
       <a href="#updates">Updates</a>
+      <a href="#graphs">Graphs</a>
     </div>
   </div>
 );

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -110,11 +110,16 @@ p {
     box-sizing: border-box;
     padding: 50px;
     text-align: center;
+
     iframe {
         margin: 0 auto;
         margin-bottom: 50px;
         border: 1px solid lightgray;
     }
+}
+
+.anchored {
+  padding-top: 80px;
 }
 
 @media (min-width: 802px) {


### PR DESCRIPTION
Part of #57 (feel free to close if you think this has sufficiently reduced the jank)

## Before
![links-before](https://user-images.githubusercontent.com/96776/45568309-2173eb80-b811-11e8-8945-f2641cb94159.gif)

## After
![links-after](https://user-images.githubusercontent.com/96776/45568308-2173eb80-b811-11e8-8dc5-b4bee731e903.gif)

