### PR TITLE
Change Dashboard link to be an anchor to the top of the page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,5 +4,5 @@
     <meta charset="UTF-8">
     <title>SUL Searchworks Status</title>
   </head>
-  <body>
+  <body id="top">
 </html>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,7 +6,7 @@ const Header = () => (
       <h1>Searchworks Status</h1>
     </div>
     <div className="nav-menu">
-      <a href="/">Dashboard</a>
+      <a href="#top">Dashboard</a>
       <a href="#updates">Updates</a>
       <a href="#graphs">Graphs</a>
     </div>


### PR DESCRIPTION
Linking to "/" doesn't work in our deployed app on GH-pages.

This won't "refresh" the page as was the behavior before (at least locally), but I'm not sure if that would be the expectation of clicking that link or not. ¯\\_(ツ)_/¯