### PR TITLE
Use justify-content for aligning the nav-menu links.

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -108,7 +108,7 @@ h3.service-name {
 .nav-menu {
   display:flex;
   flex: 1;
-  text-align: right;
+  justify-content: flex-end;
 }
 
 .nav-menu a {


### PR DESCRIPTION
Fixes #95 

It is aligned similarly as the `Stanford Libraries` logo, but not necessarily w/ the table below.  @jvine should both `Stanford Libraries` and the links be aligned w/ the table below or what the screenshot shows below the desired behavior?

## After
<img width="1674" alt="after" src="https://user-images.githubusercontent.com/96776/46435378-14109980-c70b-11e8-8f96-244bee558f73.png">

