### PR TITLE
Reword performance metrics section

### DIFF
--- a/src/components/GraphPanel.jsx
+++ b/src/components/GraphPanel.jsx
@@ -4,8 +4,11 @@ import TabbedGraphs from './TabbedGraphs';
 
 const GraphPanel = ({ graphs }) => (
   <div id="graphs" className="section anchored">
-    <h2>Performance metrics</h2>
-    <p>Sharp spikes in the graphs may have been experienced as momentary outages.</p>
+    <h2>SearchWorks performance metrics</h2>
+    <p>These graphs show response times of the SearchWorks application and its indexes.</p>
+    {/* eslint-disable max-len */}
+    <p>The team is alerted when response time reaches a threshold and remains there for 5 minutes. These incidents show as light-pink bars in the graphs. A brief spike in a graph may represent a momentary outage without triggering an alert.</p>
+    {/* eslint-enable max-len */}
     {
       Object.keys(graphs).map(graphKey => (
         <TabbedGraphs graph={graphs[graphKey]} key={graphKey} />

--- a/src/config.js
+++ b/src/config.js
@@ -118,7 +118,7 @@ export const maintenanceWindows = [
 
 export const graphs = {
   swResponseTime: {
-    title: 'SearchWorks page load time',
+    title: 'Page load time',
     position: 1,
     horizons: [
       { label: '6 hours', iframeSrc: 'https://rpm.newrelic.com/public/charts/9ALOIQ1o17Q' },


### PR DESCRIPTION
Part of #115 

This PR rewords the SearchWorks performance metrics section now that the app has been refocused on wider library system status.

## Before
![before](https://user-images.githubusercontent.com/5402927/47247125-7b3e7700-d3b6-11e8-9715-568bb7479492.png)

## After
![reworded](https://user-images.githubusercontent.com/5402927/47247126-7b3e7700-d3b6-11e8-9a9d-a4d8923a4667.png)

