### PR TITLE
Add links for some service names

### DIFF
--- a/__tests__/components/StatusItem.test.js
+++ b/__tests__/components/StatusItem.test.js
@@ -29,6 +29,11 @@ describe('<StatusItem />', () => {
 
     expect(wrapper.find('.service-name').text()).toEqual('Great Service!')
   });
+  it('adds a link to the service name if URL is provided', () => {
+    const wrapper = shallow(<StatusItem serviceName={ 'Great Service!' } serviceUrl={'https://searchworks.stanford.edu'}/>)
+    expect(wrapper.find('.service-name').text()).toEqual('Great Service!')
+    expect(wrapper.find('.status-text a').prop('href')).toEqual('https://searchworks.stanford.edu')
+  });
   it('displays the status message', () => {
     const wrapper = shallow(<StatusItem statusMessage={ 'up' }/>)
 

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -141,6 +141,7 @@ class Dashboard extends React.Component {
               <StatusItem
                 key={endpointName}
                 serviceName={endpoint.displayName}
+                serviceUrl={endpoint.serviceUrl}
                 serviceStatus={endpoint.status}
                 statusMessage={statuses[endpoint.status].message}
                 statusIcon={statuses[endpoint.status].icon}

--- a/src/components/StatusItem.jsx
+++ b/src/components/StatusItem.jsx
@@ -1,23 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const StatusItem = ({
-  serviceStatus, serviceName, statusMessage, statusIcon,
-}) => (
-  <div className={`status-item ${serviceStatus}`}>
-    <div className="status-icon">{statusIcon}</div>
-    <div className="status-text">
-      <h3 className="service-name">{serviceName}</h3>
-      <p className="status-message">{statusMessage}</p>
-    </div>
-  </div>
-);
+class StatusItem extends React.Component {
+  hasUrl() {
+    const { serviceUrl, serviceName } = this.props;
+    if (serviceUrl != null) {
+      return <a href={serviceUrl}><h3 className="service-name">{serviceName}</h3></a>;
+    }
+
+    return <h3 className="service-name">{serviceName}</h3>;
+  }
+
+  // serviceStatus, serviceName, statusMessage, statusIcon, serviceUrl,
+  render() {
+    const {
+      serviceStatus, statusMessage, statusIcon,
+    } = this.props;
+    return (
+      <div className={`status-item ${serviceStatus}`}>
+        <div className="status-icon">{statusIcon}</div>
+        <div className="status-text">
+          {this.hasUrl()}
+          <p className="status-message">{statusMessage}</p>
+        </div>
+      </div>
+    );
+  }
+}
 
 StatusItem.propTypes = {
   serviceStatus: PropTypes.string.isRequired,
   serviceName: PropTypes.string.isRequired,
   statusMessage: PropTypes.string.isRequired,
   statusIcon: PropTypes.string.isRequired,
+  serviceUrl: PropTypes.string,
 };
+
+StatusItem.defaultProps = {
+  serviceUrl: null,
+};
+
 
 export default StatusItem;

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@ export const statusEndpoints = {
   swSolr: {
     displayName: 'SearchWorks catalog (Solr)',
     endpointUrl: 'https://searchworks.stanford.edu/status/all.json',
+    serviceUrl: 'https://searchworks.stanford.edu',
     status: 'pending',
     critical: true,
     position: 1,
@@ -9,6 +10,7 @@ export const statusEndpoints = {
   ebsco: {
     displayName: 'Articles+ (EDS)',
     endpointUrl: 'https://status.ebsco.com/index.json',
+    serviceUrl: 'https://searchworks.stanford.edu/articles',
     status: 'pending',
     critical: true,
     position: 2,
@@ -16,12 +18,14 @@ export const statusEndpoints = {
   libraryDrupal: {
     displayName: 'Library website',
     endpointUrl: 'https://library.stanford.edu/healthcheck.php',
+    serviceUrl: 'https://library.stanford.edu/',
     status: 'pending',
     position: 3,
   },
   libraryHours: {
     displayName: 'Library hours',
     endpointUrl: 'https://library-hours.stanford.edu/status/all.json',
+    serviceUrl: 'https://library-hours.stanford.edu',
     status: 'pending',
     position: 4,
   },

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13,6 +13,32 @@ p {
     margin: 0;
 }
 
+a, a h3.service-name {
+  border-bottom: 0;
+  color: #006cb8;
+  text-decoration: none;
+}
+
+a:hover, a:focus {
+  border-bottom: 1px solid #00548f;
+  color: #00548f;
+  text-decoration: none;
+}
+
+a:active {
+  border-bottom: 2px solid #00548f;
+  color: #00548f;
+  text-decoration: none;
+}
+
+.brand-logo a:hover,
+.brand-logo a:focus,
+.brand-logo a:active {
+  border-bottom: none;
+  text-decoration: none;
+}
+
+
 h1 {
   font-size: 2.441em;
   font-weight: 300;


### PR DESCRIPTION
Part of #115 

This PR allows us to add links to the services table. Add a `serviceUrl` to the relevant service in the `config.js`.


TODO:
- [x] tests!
- [x] prevent empty `<a>` tags rendering for services that don't have a `serviceUrl`
- [x] rebase once #120 gets merged