### PR TITLE
Restyle services list header

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -130,10 +130,10 @@ class Dashboard extends React.Component {
         <GlobalStatusSummary
           status={new GlobalStatus(statuses, endpoints).status}
         />
+        <StatusHeader
+          statuses={statuses}
+        />
         <div id="services">
-          <StatusHeader
-            statuses={statuses}
-          />
           {Object.keys(endpoints).map((endpointName) => {
             // Return the element. Also pass key
             const endpoint = endpoints[endpointName];

--- a/src/components/StatusHeader.jsx
+++ b/src/components/StatusHeader.jsx
@@ -3,6 +3,10 @@ import React from 'react';
 const StatusHeader = () => (
   <div id="status-header">
     <h2>Current service status</h2>
+    {/* eslint-disable max-len */}
+    <p>This section shows a snapshot of Stanford Libraries systems and services, as reported by our monitoring systems. (Some systems are not yet represented here.)</p>
+    <p>Any issues shown below have been reported to the appropriate operations and development teams.</p>
+    {/* eslint-enable max-len */}
   </div>
 );
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -175,14 +175,19 @@ h3.service-name {
 }
 
 #status-header {
-  width: 100%;
-  box-sizing: border-box;
-  border-width: 0 1px 1px 0;
-  border-color: lightgray;
-  border-style: solid;
-  padding: 0 20px;
-  background-color: #F5F5F5;
   text-align: center;
+}
+
+#status-header p {
+  padding: 0 0 10px 0;
+  width: 60%;
+  margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+  #status-header p {
+    max-width: 750px;
+  }
 }
 
 .graphTabs {


### PR DESCRIPTION
Part of #115

## Before
<img width="1389" alt="old_header" src="https://user-images.githubusercontent.com/5402927/47395650-590d6780-d6dc-11e8-8d81-b7335eacea18.png">

## After
<img width="1340" alt="restyled header with descriptive info" src="https://user-images.githubusercontent.com/5402927/47395651-590d6780-d6dc-11e8-87fb-7c897bb71611.png">

