### PR TITLE
Add feedback links to footer

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { hot } from 'react-hot-loader';
 import Header from './Header';
 import Dashboard from './Dashboard';
+import Footer from './Footer';
 import '../styles/main.css';
 
 const App = () => (
   <div id="app">
     <Header />
     <Dashboard />
+    <Footer />
   </div>
 );
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const Footer = () => (
+  <div id="footer">
+    <p>
+      Need to reach us? Try
+      <a href="https://searchworks.stanford.edu/feedback">
+        SearchWorks feedback
+      </a>
+       or
+      <a href="https://library.stanford.edu/ask/email/feedback">
+        Library website feedback.
+      </a>
+    </p>
+  </div>
+);
+
+export default Footer;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -67,6 +67,9 @@ h3.service-name {
     width: 750px;
     margin: 0 auto;
   }
+  #footer {
+    width: 750px;
+  }
   .display-large {
     display: inherit;
   }
@@ -82,6 +85,9 @@ h3.service-name {
     width: 970px;
     margin: 0 auto;
   }
+  #footer {
+    width: 970px;
+  }
 }
 @media (min-width: 1200px) {
   #app {
@@ -90,6 +96,9 @@ h3.service-name {
   #header {
     width: 1170px;
     margin: 0 auto;
+  }
+  #footer {
+    width: 1170px;
   }
 }
 
@@ -326,4 +335,9 @@ h3.service-name {
     to {
         transform:rotate(360deg);
     }
+}
+
+#footer {
+  margin: 20px auto;
+  text-align: center;
 }


### PR DESCRIPTION
Another lil' part of #115.

This PR adds links to the SearchWorks and library website feedback forms. 

Note: ho boy this stylesheet is getting unwieldy. 

<img width="1349" alt="screen shot 2018-10-23 at 4 44 53 pm" src="https://user-images.githubusercontent.com/5402927/47397413-f7e99200-d6e3-11e8-9f44-6a23be7a221c.png">



