### PR TITLE
Various CSS tweaks per #115

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -178,6 +178,7 @@ h3.service-name {
     box-sizing: border-box;
     padding: 0;
     margin: 50px;
+    margin-bottom: 0;
     border-width: 1px 0 0 1px;
     border-color: lightgray;
     border-style: solid;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -206,10 +206,13 @@ h3.service-name {
 
 .graphTabs button {
   border: 1px solid black;
+  border-color: #737373;
   border-right: none;
   cursor: pointer;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 1rem;
   margin: 0;
-  padding: 10px 50px;
+  padding: 10px 20px;
 }
 
 .graphTabs button.active {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -265,7 +265,6 @@ h3.service-name {
 .section {
     width: 100%;
     box-sizing: border-box;
-    padding: 50px;
     text-align: center;
 
     iframe {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -21,7 +21,7 @@ h1 {
 }
 
 h2 {
-  font-size: 1.953em;
+  font-size: 2.441em;
   font-weight: 300;
   color: #544948;
 }


### PR DESCRIPTION
Part of #115 

Not sure if this was intentional or not, but one part that looks a bit odd is the spacing above the global status indicator due to the padding removal on `.section`:

<img width="740" alt="screen shot 2018-10-24 at 9 40 00 pm" src="https://user-images.githubusercontent.com/96776/47476472-7a9e4a00-d7d5-11e8-8eba-29fbca2caea2.png">
