### PR TITLE
Prevent navbar from overlapping global status

### DIFF
--- a/src/components/GlobalStatusSummary.jsx
+++ b/src/components/GlobalStatusSummary.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const GlobalStatusSummary = ({ status }) => (
 
-  <div id="GlobalStatusSummary" className="section">
+  <div id="GlobalStatusSummary" className="section anchored">
     <div className="status-icon">{status.icon}</div>
     <div className="status-legend">{status.legend}</div>
     <p>


### PR DESCRIPTION
Closes #138 

## Before
![navbar overlapping global status indicator](https://user-images.githubusercontent.com/5402927/47872280-61942b00-ddcb-11e8-86b2-c64acec66434.png)

## After
![fixed](https://user-images.githubusercontent.com/5402927/47872281-61942b00-ddcb-11e8-9851-8972fb01cb2c.png)

