### PR TITLE
Update graphs to use new NewRelic graphs (old ones were broken).

### DIFF
--- a/__tests__/components/TabbedGraphs.test.js
+++ b/__tests__/components/TabbedGraphs.test.js
@@ -55,13 +55,13 @@ describe('<TabbedGraphs />', () => {
       const wrapper = shallow(<TabbedGraphs graph={graphs.swResponseTime} />);
 
       expect(wrapper.find('Graph').prop('graph').iframeSrc).toEqual(
-        'https://rpm.newrelic.com/public/charts/9ALOIQ1o17Q'
+        'https://rpm.newrelic.com/public/charts/47JE5FsWnMD'
       );
 
       wrapper.setState({ activeIndex: 2 });
 
       expect(wrapper.find('Graph').prop('graph').iframeSrc).toEqual(
-        'https://rpm.newrelic.com/public/charts/9dxzdf4V71h'
+        'https://rpm.newrelic.com/public/charts/8RpiSIXjRBF'
       );
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6873,7 +6873,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6894,12 +6895,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6914,17 +6917,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7041,7 +7047,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7053,6 +7060,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7067,6 +7075,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7074,12 +7083,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7098,6 +7109,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7178,7 +7190,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7190,6 +7203,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7275,7 +7289,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7311,6 +7326,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7330,6 +7346,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7373,12 +7390,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12420,7 +12439,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/src/config.js
+++ b/src/config.js
@@ -151,25 +151,25 @@ export const graphs = {
     title: 'Page load time',
     position: 1,
     horizons: [
-      { label: '6 hours', iframeSrc: 'https://rpm.newrelic.com/public/charts/9ALOIQ1o17Q' },
-      { label: '3 days', iframeSrc: 'https://rpm.newrelic.com/public/charts/c6qFHIdWFdG' },
-      { label: '30 days', iframeSrc: 'https://rpm.newrelic.com/public/charts/9dxzdf4V71h' },
+      { label: '6 hours', iframeSrc: 'https://rpm.newrelic.com/public/charts/47JE5FsWnMD' },
+      { label: '3 days', iframeSrc: 'https://rpm.newrelic.com/public/charts/bTisUaCTW3z' },
+      { label: '30 days', iframeSrc: 'https://rpm.newrelic.com/public/charts/8RpiSIXjRBF' },
     ],
   },
   solr: {
     title: 'Catalog index (Solr) response time',
     position: 2,
     horizons: [
-      { label: '6 hours', iframeSrc: 'https://rpm.newrelic.com/public/charts/80xp1hfSf6h' },
-      { label: '3 days', iframeSrc: 'https://rpm.newrelic.com/public/charts/biAaCaONpRC' },
+      { label: '6 hours', iframeSrc: 'https://rpm.newrelic.com/public/charts/fL0sJurf9eZ' },
+      { label: '3 days', iframeSrc: 'https://rpm.newrelic.com/public/charts/4zYnObHnQij' },
     ],
   },
   ebsco: {
     title: 'Articles+ (EDS) response time',
     position: 3,
     horizons: [
-      { label: '6 hours', iframeSrc: 'https://rpm.newrelic.com/public/charts/cfcfetW1YGr' },
-      { label: '3 days', iframeSrc: 'https://rpm.newrelic.com/public/charts/bgq3iP9fhSo' },
+      { label: '6 hours', iframeSrc: 'https://rpm.newrelic.com/public/charts/eZp3HEze2w8' },
+      { label: '3 days', iframeSrc: 'https://rpm.newrelic.com/public/charts/9GsYfLT6hlr' },
     ],
   },
 };


### PR DESCRIPTION
## Before
<img width="868" alt="Screen Shot 2019-12-02 at 3 34 56 PM" src="https://user-images.githubusercontent.com/96776/70006758-2b236500-1523-11ea-8012-365c8225a002.png">

## After
<img width="826" alt="Screen Shot 2019-12-02 at 4 45 28 PM" src="https://user-images.githubusercontent.com/96776/70006757-2b236500-1523-11ea-94ae-ce7880f6ab35.png">

