### PR TITLE
Group endpoints by their URL and then only make requests once per URL.

### DIFF
--- a/__tests__/components/Dashboard.test.js
+++ b/__tests__/components/Dashboard.test.js
@@ -1,0 +1,26 @@
+import Dashboard from '../../src/components/Dashboard';
+
+describe('Dashboard', () => {
+  describe('.groupedEndpoints', () => {
+    it('groups all configured statusEndpoints by their endpoint URL', () => {
+      const groupedEndpoints = new Dashboard({}).groupedEndpoints();
+      expect(Object.keys(groupedEndpoints)).toEqual([
+        'https://searchworks.stanford.edu/status/all.json',
+        'https://status.ebsco.com/index.json',
+        'https://library.stanford.edu/healthcheck.php',
+        'https://library-hours.stanford.edu/status/all.json',
+        'https://requests.stanford.edu/status/all.json',
+        'https://embed.stanford.edu/status/all.json',
+        'https://mylibrary.stanford.edu/status/all.json',
+      ]);
+
+      expect(Object.keys(groupedEndpoints['https://searchworks.stanford.edu/status/all.json'])).toEqual([
+        'swSolr', 'liveAvailability', 'citationService',
+      ]);
+
+      expect(groupedEndpoints['https://searchworks.stanford.edu/status/all.json']['swSolr']['displayName']).toEqual(
+        'SearchWorks catalog (Solr)',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Currently, the user needs to request the SearchWorks status endpoint 3 times to load the dashboard.  This allows us to only hit an endpoint like SearchWorks once and then send the response to the various endpoint specific processors.