### PR TITLE
Refactoring some components to simplify some, and constrain re-renders

### DIFF
--- a/__tests__/components/Dashboard.test.js
+++ b/__tests__/components/Dashboard.test.js
@@ -57,10 +57,10 @@ describe('Dashboard', () => {
     expect(wrapper.find('div#services StatusItem').length).toEqual(expectedItems);
   });
 
-  it('renders the TabbedTwitterFeeds', () => {
+  it('renders the UpdatesPanel', () => {
     const wrapper = shallow(<Dashboard />);
 
-    expect(wrapper.find('TabbedTwitterFeeds').length).toEqual(1);
+    expect(wrapper.find('UpdatesPanel').length).toEqual(1);
   });
 
   it('renders the GraphPanel', () => {

--- a/__tests__/components/Dashboard.test.js
+++ b/__tests__/components/Dashboard.test.js
@@ -1,60 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { statusEndpoints, statuses } from '../../src/config';
 import Dashboard from '../../src/components/Dashboard';
 
 
 describe('Dashboard', () => {
-  let json = {};
-  let text = '';
-  let status = 200;
-
-  beforeEach(() => {
-    global.fetch = jest.fn(() => Promise.resolve({
-      status,
-      clone: () => (
-        {
-          json: () => Promise.resolve(json),
-          text: () => Promise.resolve(text),
-        }
-      ),
-    }));
-  });
-
-  it('renders the GlobalStatusSummary w/ an initital (pending/loading) status', () => {
-    const wrapper = shallow(<Dashboard />);
-    const summary = wrapper.find('GlobalStatusSummary');
-
-    expect(summary.length).toEqual(1);
-    expect(summary.props().status).toEqual(statuses.pending);
-  });
-
-  it('renders the Dashboard with the endpoints stored in state', () => {
-    const wrapper = shallow(<Dashboard />);
-    expect(wrapper.state().endpoints).toEqual(wrapper.state().endpoints);
-  });
-
-  describe('processing responses', () => {
-    json = { default: true, sw_solr: { success: true }, low_app_apdex_alert: { success: true } };
-
-    it('processes the statuses based on the returned response', () => {
-      let wrapper = shallow(<Dashboard />);
-
-      expect(wrapper.find('div#services StatusItem').at(0).props().serviceStatus).toEqual('up'); // Stubbed success above
-      expect(wrapper.find('div#services StatusItem').at(1).props().serviceStatus).toEqual('outage');
-    });
-  });
-
-  it('renders the StatusHeader', () => {
+  it('renders the StatusPanel', () => {
     const wrapper = shallow(<Dashboard />);
 
-    expect(wrapper.find('StatusHeader').length).toEqual(1);
-  });
-
-  it('renders a Status Item for each check in the config', () => {
-    const wrapper = shallow(<Dashboard />);
-    const expectedItems = Object.keys(statusEndpoints).length;
-    expect(wrapper.find('div#services StatusItem').length).toEqual(expectedItems);
+    expect(wrapper.find('UpdatesPanel').length).toEqual(1);
   });
 
   it('renders the UpdatesPanel', () => {
@@ -67,28 +20,5 @@ describe('Dashboard', () => {
     const wrapper = shallow(<Dashboard />);
 
     expect(wrapper.find('GraphPanel').length).toEqual(1);
-  });
-
-  describe('.groupedEndpoints', () => {
-    it('groups all configured statusEndpoints by their endpoint URL', () => {
-      const groupedEndpoints = new Dashboard({}).groupedEndpoints();
-      expect(Object.keys(groupedEndpoints)).toEqual([
-        'https://searchworks.stanford.edu/status/all.json',
-        'https://status.ebsco.com/index.json',
-        'https://library.stanford.edu/healthcheck.php',
-        'https://library-hours.stanford.edu/status/all.json',
-        'https://requests.stanford.edu/status/all.json',
-        'https://embed.stanford.edu/status/all.json',
-        'https://mylibrary.stanford.edu/status/all.json',
-      ]);
-
-      expect(Object.keys(groupedEndpoints['https://searchworks.stanford.edu/status/all.json'])).toEqual([
-        'swSolr', 'liveAvailability', 'citationService',
-      ]);
-
-      expect(groupedEndpoints['https://searchworks.stanford.edu/status/all.json']['swSolr']['displayName']).toEqual(
-        'SearchWorks catalog (Solr)',
-      );
-    });
   });
 });

--- a/__tests__/components/GraphPanel.test.js
+++ b/__tests__/components/GraphPanel.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import GraphPanel from '../../src/components/GraphPanel';
+
+describe('GraphPanel', () => {
+  it('renders TabbedGraphs for each configured graph', () => {
+    const wrapper = shallow(<GraphPanel />);
+
+    expect(wrapper.find('TabbedGraphs').length).toEqual(3);
+  });
+});

--- a/__tests__/components/ServiceGrid.test.js
+++ b/__tests__/components/ServiceGrid.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { statusEndpoints } from '../../src/config';
+import ServiceGrid from '../../src/components/ServiceGrid';
+
+function shallowWrapper(props) {
+  return shallow(
+    <ServiceGrid
+      endpoints={{}}
+      {...props}
+    />
+  );
+}
+
+describe('ServiceGrid', () => {
+  const endpoints = {
+    ...statusEndpoints,
+    swSolr: { ...statusEndpoints.swSolr, status: 'up' },
+    embed: { ...statusEndpoints.embed, status: 'outage' },
+  };
+
+  it('renders a Status Item for each check in the config', () => {
+    const wrapper = shallowWrapper({ endpoints });
+
+    expect(wrapper.find('div#services StatusItem').length).toEqual(9);
+  });
+
+  it('passes the approrpiate props to the StatusItem', () => {
+    const wrapper = shallowWrapper({ endpoints });
+
+    expect(wrapper.find('div#services StatusItem').at(0).props().serviceStatus).toEqual('up'); // Stubbed success above
+    expect(wrapper.find('div#services StatusItem').at(5).props().serviceStatus).toEqual('outage');
+  });
+});

--- a/__tests__/components/StatusPanel.test.js
+++ b/__tests__/components/StatusPanel.test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { statuses } from '../../src/config';
+import StatusPanel from '../../src/components/StatusPanel';
+
+describe('StatusPanel', () => {
+  let json = {};
+  let text = '';
+  let status = 200;
+
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.resolve({
+      status,
+      clone: () => (
+        {
+          json: () => Promise.resolve(json),
+          text: () => Promise.resolve(text),
+        }
+      ),
+    }));
+  });
+
+  it('renders the GlobalStatusSummary w/ an initital (pending/loading) status', () => {
+    const wrapper = shallow(<StatusPanel />);
+    const summary = wrapper.find('GlobalStatusSummary');
+
+    expect(summary.length).toEqual(1);
+    expect(summary.props().status).toEqual(statuses.pending);
+  });
+
+  it('renders the Dashboard with the endpoints stored in state', () => {
+    const wrapper = shallow(<StatusPanel />);
+    expect(wrapper.state().endpoints).toEqual(wrapper.state().endpoints);
+  });
+
+  describe('processing responses', () => {
+    json = { default: true, sw_solr: { success: true }, low_app_apdex_alert: { success: true } };
+
+    it('processes the statuses based on the returned response', () => {
+      let wrapper = shallow(<StatusPanel />);
+
+      expect(wrapper.state().endpoints.swSolr.status).toEqual('up');
+      expect(wrapper.state().endpoints.embed.status).toEqual('outage');
+    });
+  });
+
+  it('renders the StatusHeader', () => {
+    const wrapper = shallow(<StatusPanel />);
+
+    expect(wrapper.find('StatusHeader').length).toEqual(1);
+  });
+
+  describe('.groupedEndpoints', () => {
+    it('groups all configured statusEndpoints by their endpoint URL', () => {
+      const groupedEndpoints = new StatusPanel({}).groupedEndpoints();
+      expect(Object.keys(groupedEndpoints)).toEqual([
+        'https://searchworks.stanford.edu/status/all.json',
+        'https://status.ebsco.com/index.json',
+        'https://library.stanford.edu/healthcheck.php',
+        'https://library-hours.stanford.edu/status/all.json',
+        'https://requests.stanford.edu/status/all.json',
+        'https://embed.stanford.edu/status/all.json',
+        'https://mylibrary.stanford.edu/status/all.json',
+      ]);
+
+      expect(Object.keys(groupedEndpoints['https://searchworks.stanford.edu/status/all.json'])).toEqual([
+        'swSolr', 'liveAvailability', 'citationService',
+      ]);
+
+      expect(groupedEndpoints['https://searchworks.stanford.edu/status/all.json']['swSolr']['displayName']).toEqual(
+        'SearchWorks catalog (Solr)',
+      );
+    });
+  });
+});

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,110 +1,14 @@
 import React from 'react';
-import {
-  statusEndpoints, statuses, maintenanceWindows,
-} from '../config';
-import * as processors from '../utils/endpointParsers';
-import GlobalStatus from '../utils/globalStatus';
-import GlobalStatusSummary from './GlobalStatusSummary';
-import StatusHeader from './StatusHeader';
-import StatusItem from './StatusItem';
+import StatusPanel from './StatusPanel';
 import GraphPanel from './GraphPanel';
 import UpdatesPanel from './UpdatesPanel';
-import areBeingMaintained from '../utils/maintenanceUtils';
 
-class Dashboard extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { endpoints: statusEndpoints };
-  }
-
-  componentDidMount() {
-    const { endpoints } = this.state;
-    const maintenanceWindow = areBeingMaintained(new Date(), maintenanceWindows);
-    const groupedEndpoints = this.groupedEndpoints();
-
-    Object.keys(groupedEndpoints).forEach((endpointUrl) => {
-      fetch(endpointUrl, {
-        mode: 'cors',
-      }).then((response) => {
-        Object.keys(groupedEndpoints[endpointUrl]).forEach((key) => {
-          if (response.status !== 200) {
-            const newState = endpoints;
-            if (maintenanceWindow) {
-              newState[key].status = 'maintenance';
-            } else {
-              newState[key].status = 'issue';
-            }
-            this.setState(newState);
-            return;
-          }
-
-          processors[endpoints[key].processor](response.clone())
-            .then((status) => {
-              const newState = endpoints;
-              newState[key].status = status;
-              this.setState(newState);
-            });
-        });
-      }).catch(() => {
-        Object.keys(groupedEndpoints[endpointUrl]).forEach((key) => {
-          const newState = endpoints;
-          newState[key].status = 'outage';
-          this.setState(newState);
-        });
-      });
-    });
-  }
-
-  groupedEndpoints() {
-    const { endpoints } = this.state;
-    const endpointCache = {};
-
-    Object.keys(endpoints).forEach((key) => {
-      const current = endpoints[key];
-      const { endpointUrl } = current;
-
-      if (endpointCache[endpointUrl]) {
-        endpointCache[endpointUrl][key] = current;
-      } else {
-        endpointCache[endpointUrl] = { [key]: current };
-      }
-    });
-    return endpointCache;
-  }
-
-  render() {
-    const { endpoints } = this.state;
-    return (
-      <div>
-        <GlobalStatusSummary
-          status={new GlobalStatus(statuses, endpoints).status}
-        />
-        <StatusHeader
-          statuses={statuses}
-        />
-        <div id="services">
-          {Object.keys(endpoints).map((endpointName) => {
-            // Return the element. Also pass key
-            const endpoint = endpoints[endpointName];
-            return (
-              <StatusItem
-                key={endpointName}
-                serviceName={endpoint.displayName}
-                serviceUrl={endpoint.serviceUrl}
-                serviceStatus={endpoint.status}
-                statusMessage={statuses[endpoint.status].message}
-                statusIcon={statuses[endpoint.status].icon}
-              />
-            );
-          })}
-
-        </div>
-
-        <UpdatesPanel />
-        <GraphPanel />
-      </div>
-    );
-  }
-}
+const Dashboard = () => (
+  <>
+    <StatusPanel />
+    <UpdatesPanel />
+    <GraphPanel />
+  </>
+);
 
 export default Dashboard;

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -8,7 +8,7 @@ import GlobalStatusSummary from './GlobalStatusSummary';
 import StatusHeader from './StatusHeader';
 import StatusItem from './StatusItem';
 import GraphPanel from './GraphPanel';
-import TabbedTwitterFeeds from './TabbedTwitterFeeds';
+import UpdatesPanel from './UpdatesPanel';
 import areBeingMaintained from '../utils/maintenanceUtils';
 
 class Dashboard extends React.Component {
@@ -74,9 +74,6 @@ class Dashboard extends React.Component {
 
   render() {
     const { endpoints } = this.state;
-    const feeds = [
-      { feedId: 'sulsystemstatus', label: 'Library systems' },
-      { feedId: 'suleresources', label: 'Databases & e-resources' }];
     return (
       <div>
         <GlobalStatusSummary
@@ -102,11 +99,8 @@ class Dashboard extends React.Component {
           })}
 
         </div>
-        <div id="updates" className="section anchored">
-          <h2>Incidents</h2>
-          <p>Updates about planned and unplanned service interruptions.</p>
-          <TabbedTwitterFeeds feeds={feeds} />
-        </div>
+
+        <UpdatesPanel />
         <GraphPanel />
       </div>
     );

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  statusEndpoints, statuses, graphs, maintenanceWindows,
+  statusEndpoints, statuses, maintenanceWindows,
 } from '../config';
 import * as processors from '../utils/endpointParsers';
 import GlobalStatus from '../utils/globalStatus';
@@ -107,7 +107,7 @@ class Dashboard extends React.Component {
           <p>Updates about planned and unplanned service interruptions.</p>
           <TabbedTwitterFeeds feeds={feeds} />
         </div>
-        <GraphPanel graphs={graphs} />
+        <GraphPanel />
       </div>
     );
   }

--- a/src/components/GraphPanel.jsx
+++ b/src/components/GraphPanel.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { graphs } from '../config';
 import TabbedGraphs from './TabbedGraphs';
 
-const GraphPanel = ({ graphs }) => (
+
+const GraphPanel = () => (
   <div id="graphs" className="section anchored">
     <h2>SearchWorks performance metrics</h2>
     <p>These graphs show response times of the SearchWorks application and its indexes.</p>
@@ -16,10 +17,5 @@ const GraphPanel = ({ graphs }) => (
     }
   </div>
 );
-
-GraphPanel.propTypes = {
-  graphs: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-};
-
 
 export default GraphPanel;

--- a/src/components/ServiceGrid.jsx
+++ b/src/components/ServiceGrid.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StatusItem from './StatusItem';
+import { statuses } from '../config';
+
+const ServiceGrid = ({ endpoints }) => (
+  <div id="services">
+    {Object.keys(endpoints || {}).map((endpointName) => {
+      // Return the element. Also pass key
+      const endpoint = endpoints[endpointName];
+      return (
+        <StatusItem
+          key={endpointName}
+          serviceName={endpoint.displayName}
+          serviceUrl={endpoint.serviceUrl}
+          serviceStatus={endpoint.status}
+          statusMessage={statuses[endpoint.status].message}
+          statusIcon={statuses[endpoint.status].icon}
+        />
+      );
+    })}
+  </div>
+);
+
+ServiceGrid.propTypes = {
+  endpoints: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+export default ServiceGrid;

--- a/src/components/StatusPanel.jsx
+++ b/src/components/StatusPanel.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import GlobalStatus from '../utils/globalStatus';
+import GlobalStatusSummary from './GlobalStatusSummary';
+import StatusHeader from './StatusHeader';
+import ServiceGrid from './ServiceGrid';
+import {
+  statusEndpoints, statuses, maintenanceWindows,
+} from '../config';
+import * as processors from '../utils/endpointParsers';
+import areBeingMaintained from '../utils/maintenanceUtils';
+
+class StatusPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { endpoints: statusEndpoints };
+  }
+
+  componentDidMount() {
+    const { endpoints } = this.state;
+    const maintenanceWindow = areBeingMaintained(new Date(), maintenanceWindows);
+    const groupedEndpoints = this.groupedEndpoints();
+
+    Object.keys(groupedEndpoints).forEach((endpointUrl) => {
+      fetch(endpointUrl, {
+        mode: 'cors',
+      }).then((response) => {
+        Object.keys(groupedEndpoints[endpointUrl]).forEach((key) => {
+          if (response.status !== 200) {
+            const newState = endpoints;
+            if (maintenanceWindow) {
+              newState[key].status = 'maintenance';
+            } else {
+              newState[key].status = 'issue';
+            }
+            this.setState(newState);
+            return;
+          }
+
+          processors[endpoints[key].processor](response.clone())
+            .then((status) => {
+              const newState = endpoints;
+              newState[key].status = status;
+              this.setState(newState);
+            });
+        });
+      }).catch(() => {
+        Object.keys(groupedEndpoints[endpointUrl]).forEach((key) => {
+          const newState = endpoints;
+          newState[key].status = 'outage';
+          this.setState(newState);
+        });
+      });
+    });
+  }
+
+  groupedEndpoints() {
+    const { endpoints } = this.state;
+    const endpointCache = {};
+
+    Object.keys(endpoints).forEach((key) => {
+      const current = endpoints[key];
+      const { endpointUrl } = current;
+
+      if (endpointCache[endpointUrl]) {
+        endpointCache[endpointUrl][key] = current;
+      } else {
+        endpointCache[endpointUrl] = { [key]: current };
+      }
+    });
+    return endpointCache;
+  }
+
+  render() {
+    const { endpoints } = this.state;
+
+    return (
+      <>
+        <GlobalStatusSummary
+          status={new GlobalStatus(statuses, endpoints).status}
+        />
+        <StatusHeader
+          statuses={statuses}
+        />
+        <ServiceGrid endpoints={endpoints} />
+      </>
+    );
+  }
+}
+
+export default StatusPanel;

--- a/src/components/TabbedTwitterFeeds.jsx
+++ b/src/components/TabbedTwitterFeeds.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { TwitterTimelineEmbed } from 'react-twitter-embed';
+import { twitterFeeds } from '../config';
 
 class TabbedTwitterFeeds extends React.Component {
   constructor(props) {
@@ -13,13 +13,12 @@ class TabbedTwitterFeeds extends React.Component {
   }
 
   setInitialActiveIndex() {
-    const { feeds } = this.props;
     const location = window.location.toString();
     const anchor = location.substring(location.indexOf('#') + 1);
-    const activeFeed = feeds.find(feed => feed.feedId === anchor);
+    const activeFeed = twitterFeeds.find(feed => feed.feedId === anchor);
 
     if (activeFeed) {
-      this.state = { activeIndex: feeds.indexOf(activeFeed) };
+      this.state = { activeIndex: twitterFeeds.indexOf(activeFeed) };
     } else {
       this.state = { activeIndex: 0 };
     }
@@ -50,12 +49,11 @@ class TabbedTwitterFeeds extends React.Component {
   }
 
   render() {
-    const { feeds } = this.props;
     return (
       <div>
         <div className="graphTabs">
           {
-            feeds.map((feed, i) => (
+            twitterFeeds.map((feed, i) => (
               <button
                 type="button"
                 role="tab"
@@ -72,7 +70,7 @@ class TabbedTwitterFeeds extends React.Component {
         </div>
         <div aria-live="polite">
           {
-            feeds.filter((feed, i) => (this.indexIsActive(i))).map(feed => (
+            twitterFeeds.filter((feed, i) => (this.indexIsActive(i))).map(feed => (
               <TwitterTimelineEmbed
                 sourceType="profile"
                 key={feed.feedId}
@@ -90,10 +88,5 @@ class TabbedTwitterFeeds extends React.Component {
     );
   }
 }
-
-TabbedTwitterFeeds.propTypes = {
-  feeds: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-};
-
 
 export default TabbedTwitterFeeds;

--- a/src/components/UpdatesPanel.jsx
+++ b/src/components/UpdatesPanel.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import TabbedTwitterFeeds from './TabbedTwitterFeeds';
+
+const UpdatesPanel = () => (
+  <div id="updates" className="section anchored">
+    <h2>Incidents</h2>
+    <p>Updates about planned and unplanned service interruptions.</p>
+    <TabbedTwitterFeeds />
+  </div>
+);
+
+export default UpdatesPanel;

--- a/src/config.js
+++ b/src/config.js
@@ -173,3 +173,8 @@ export const graphs = {
     ],
   },
 };
+
+export const twitterFeeds = [
+  { feedId: 'sulsystemstatus', label: 'Library systems' },
+  { feedId: 'suleresources', label: 'Databases & e-resources' },
+];


### PR DESCRIPTION
This pushes some components around in an attempt to simplify / unify some of the patterns and to restrict re-renders as we receive data from the endpoints to relevant components (also adds some tests along the way)