### PR TITLE
Removes dependency on moment.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10960,7 +10960,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -12532,19 +12533,6 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
-      }
-    },
-    "moment": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.28.0.tgz",
-      "integrity": "sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw=="
-    },
-    "moment-timezone": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
-      "requires": {
-        "moment": ">= 2.9.0"
       }
     },
     "moo": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,6 @@
   },
   "dependencies": {
     "lodash": "^4.17.20",
-    "moment": "^2.28.0",
-    "moment-timezone": "^0.5.31",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/utils/maintenanceUtils.js
+++ b/src/utils/maintenanceUtils.js
@@ -1,14 +1,13 @@
-import moment from 'moment';
-import 'moment-timezone';
-
 function isBeingMaintained(currentTime, interval) {
   // Given a maintenance interval, return whether
   // the current time is within that interval.
   // Take timezone into account.
-  // let currentDate = new Date
-  const currentDate = moment(currentTime).tz('America/Los_Angeles');
-  const currentHour = currentDate.hour();
-  const maintenanceDay = (interval.day === currentDate.day());
+  const currentDate = new Date(
+    new Date(currentTime).toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }),
+  );
+
+  const currentHour = currentDate.getHours();
+  const maintenanceDay = (interval.day === currentDate.getDay());
   const maintenanceInterval = (currentHour >= interval.startHour)
     && (currentHour < interval.endHour);
   return (maintenanceDay && maintenanceInterval);

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -38,7 +38,6 @@ module.exports = {
       filename: 'index.html',
       hash: true
     }),
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
   ],
   resolve: {
     extensions: ['.js', '.jsx']


### PR DESCRIPTION
Related to messaging here: https://momentjs.com/docs/#/-project-status/

But in reality we don't need this.

Also, this is not compatible with IE11, but turns out this site is already broken with IE11 and hasn't been a reported problem. 🤷 

Bundle size change (minified): 498Kb -> 249Kb 